### PR TITLE
Fix resetting visits state on app opening

### DIFF
--- a/Visits/Modules/Sources/APIEnvironmentLive/APIError.swift
+++ b/Visits/Modules/Sources/APIEnvironmentLive/APIError.swift
@@ -5,7 +5,7 @@ import NonEmpty
 import Types
 import Utility
 
-
+// also check for different callAPI overload below
 func callAPI<Success: Decodable, Failure: Decodable>(
   session: URLSession = URLSession.shared,
   request: URLRequest,

--- a/Visits/Modules/Sources/APIEnvironmentLive/Worker.swift
+++ b/Visits/Modules/Sources/APIEnvironmentLive/Worker.swift
@@ -53,7 +53,6 @@ func workerSummaryRequest(auth token: Token.Value, workerHandle: WorkerHandle, f
   components.path = "/client/workers/\(workerHandle.string)"
     
   components.queryItems = [
-    URLQueryItem(name: "worker_handle", value: workerHandle.rawValue.rawValue),
     URLQueryItem(name: "include_schedule", value: "false"),
     URLQueryItem(name: "include_summary", value: "true"),
     URLQueryItem(name: "include_timeline", value: "false"),

--- a/Visits/Modules/Sources/AppLogic/AppAction.swift
+++ b/Visits/Modules/Sources/AppLogic/AppAction.swift
@@ -33,6 +33,7 @@ public enum AppAction: Equatable {
   //   Requests
   case tokenUpdated(Result<Token.Value, APIError<Never>>)
   case cancelAllRequests
+  // on login
   case refreshAllRequests
   case receivedCurrentLocation(Coordinate?)
   //   Orders

--- a/Visits/Modules/Sources/DeepLinkLogic/DeepLinkLogic.swift
+++ b/Visits/Modules/Sources/DeepLinkLogic/DeepLinkLogic.swift
@@ -107,7 +107,7 @@ public let deepLinkReducer = Reducer<DeepLinkState, DeepLinkAction, SystemEnviro
   case .deepLinkFailed:
     return .none
   case let .applyFullDeepLink(deepLink, sdk):
-let (visitsDateFrom, visitsDateTo) = environment.defaultVisitsDatePickerFromTo()
+    let (visitsDateFrom, visitsDateTo) = environment.defaultVisitsDatePickerFromTo()
     state.flow = .main(
       .init(
         map: .initialState,

--- a/Visits/Modules/Sources/RequestLogic/RequestLogic.swift
+++ b/Visits/Modules/Sources/RequestLogic/RequestLogic.swift
@@ -500,7 +500,7 @@ public let requestReducer = Reducer<
     let currentDate = environment.date()
     let calendar = environment.calendar()
     let timeZone = environment.timeZone()
-    // Initial app data loading (after the token is refreshed). Token is also updated on the app launch
+    // Initial app data loading (after the token is refreshed). Token is also updated when the app initialized
     return .merge(
       state.requests.map(requestEffect(t))
       +

--- a/Visits/Modules/Sources/RequestLogic/RequestLogic.swift
+++ b/Visits/Modules/Sources/RequestLogic/RequestLogic.swift
@@ -225,6 +225,7 @@ public let requestReducer = Reducer<
        .receivedPushNotification,
        .mainUnlocked,
        .startTracking,
+       // happens on log in
        .refreshAllRequests:
     let isIntegrationCheckPending = state.integrationStatus == .unknown
 
@@ -240,8 +241,8 @@ public let requestReducer = Reducer<
         + [isIntegrationCheckPending ? getIntegrationEntities(t, "") : .none]
         + [getTeam(t, state.workerHandle)]
 
-      // we don't need to reload visits on app going to foreground
-      if action != .appVisibilityChanged(.onScreen) {
+      // we only need to reload visits on login here
+      if action == .refreshAllRequests {
         initialEffects = initialEffects + [
           getVisits(
             t,
@@ -499,7 +500,7 @@ public let requestReducer = Reducer<
     let currentDate = environment.date()
     let calendar = environment.calendar()
     let timeZone = environment.timeZone()
-    // Initial app data loading (after the token is refreshed)
+    // Initial app data loading (after the token is refreshed). Token is also updated on the app launch
     return .merge(
       state.requests.map(requestEffect(t))
       +

--- a/Visits/Modules/Sources/VisitsLogic/VisitsLogic.swift
+++ b/Visits/Modules/Sources/VisitsLogic/VisitsLogic.swift
@@ -40,7 +40,7 @@ public let visitsReducer = Reducer<VisitsState, VisitsAction, Void> { state, act
     }
     return .none
   case let .visitsUpdated(vd):
-    if(vd.workerHandle == state.workerHandle) {
+    if(vd.workerHandle == state.workerHandle && state.from == vd.from && state.to == vd.to) {
       state.visits = vd
     }
       


### PR DESCRIPTION
The visits update request was triggered by opening the app before, which caused the state to reset to the default date range.
It's fixed by limiting the trigger to only the post-login refresh action.

Also the reducer updated the list data with the wrong dates, so the range view and list data were out of sync.
It's fixed by rejecting the action if it updates the view for the wrong date range (the correct update first updates the state for it to match the requested dates)